### PR TITLE
Update chekout.php

### DIFF
--- a/chekout.php
+++ b/chekout.php
@@ -1,7 +1,21 @@
-<p class="form-row form-row-wide validate-required validate-region" id="shipping_region_field" data-priority="6">
+add_filter( 'woocommerce_shipping_fields', 'display_shipping_region_checkout_field', 20, 1 );
+function display_shipping_region_checkout_field( $fields ) {
+    $fields['shipping_region'] = array(
+        'type'        => 'select',
+        'label'       => __("Region", "woocommerce") ,
+        'class'       => array('form-row-wide', 'update_totals_on_change'),
+        'required'    => true,
+        'options'       => array(
+            ''         => __("Choose a region please"),
+            'option-1' => __("Option 01"),
+            'option-2' => __("Option 02"),
+            'option-3' => __("Option 03"),
+        ),
+        'priority' => 100, 
+        'clear' => true,
+    );
+    return $fields;
+}
 
-  <select name="shipping_region" id="shipping_region" class="state_select select2-selection--single" autocomplete="address-level1" data-placeholder="" tabindex="-1" aria-hidden="true">
-        <option>Opción 01</option>
-        <option>Opción 02</option>
-  </select>
-</p>
+
+// Code goes in function.php file of your active child theme (or active theme). Tested and works.


### PR DESCRIPTION
1) For normal or custom billing and shipping fields you can use woocommerce_billing_fields or woocommerce_shipping_fields action hooks on checkout page as follow.

It will make a custom checkout field required without any need to add a validation script and to save it in the order. The field will also appear in My account edit adresses field section.

Some argument explanations:

The class 'update_totals_on_change' allow to trigger "update checkout" on change.

The 'required' attribute make the field required or not

The 'priority' attribute allow you to change the location of the field.